### PR TITLE
Reduce complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 This is a [Rails application template](https://guides.rubyonrails.org/rails_application_templates.html) for an opinionated Docker setup.
 
 - Docker Compose-optimized project
-  - App, Sidekiq worker, Postgres, Redis, and Selenium services
+  - App, Postgres, Redis, and Selenium services
+  - Sidekiq worker runs via Foreman to prevent `bin/dev` or `Procfile.dev` clashes with gems you might add later
 - Binstubs that make working with Docker Compose easy
-  - `bin/dev`: Alias for `docker-compose up`
+  - `bin/compose`: Alias for `docker-compose up`
   - `bin/run`: Runs a command in the `app` service
   - `bin/credentials`: Opens the encrypted credentials file in Vim
 - Additional default gems

--- a/dockerized-rails-template.rb
+++ b/dockerized-rails-template.rb
@@ -64,6 +64,13 @@ file("config/database.yml") do
   CONFIG
 end
 
+file("Procfile.dev") do
+  <<~PROCFILE
+    web: bin/rails server -b 0.0.0.0 -p 3000
+    worker: bundle exec sidekiq
+  PROCFILE
+end
+
 file("test/application_system_test_case.rb") do
   <<~TESTCASE
     require "test_helper"
@@ -121,7 +128,7 @@ file("Dockerfile.local") do
 
     # Define default command for the container.
     EXPOSE 3000
-    CMD ["rails", "server", "-b", "0.0.0.0"]
+    CMD ["bin/dev"]
   DOCKERFILE
 end
 
@@ -148,20 +155,6 @@ file("docker-compose.yml") do
           - redis
           - selenium
 
-      worker:
-        build:
-          context: .
-          dockerfile: ./Dockerfile.local
-        command: "bundle exec sidekiq"
-        volumes:
-          - .:/app
-        environment:
-          REDIS_URL: redis://redis:6379
-          REDIS_PROVIDER: REDIS_URL
-        depends_on:
-          - db
-          - redis
-
       db:
         image: postgres:latest
         ports:
@@ -181,9 +174,18 @@ end
 
 # 4. Binstubs
 #-----------------------------------------------------------------------------------------------------------------------
+file("bin/compose") do
+  <<~BIN
+    #!/usr/bin/env bash
+
+    docker-compose up $*
+  BIN
+end
+run("chmod +x bin/compose")
+
 file("bin/credentials") do
   <<~BIN
-    #!/bin/sh
+    #!/usr/bin/env bash
 
     docker-compose run --no-deps --rm -e "EDITOR=vim" app bin/rails credentials:edit
   BIN
@@ -192,16 +194,21 @@ run("chmod +x bin/credentials")
 
 file("bin/dev") do
   <<~BIN
-    #!/bin/sh
+    #!/usr/bin/env bash
 
-    docker-compose up $*
+    if ! gem list foreman -i --silent; then
+      echo "Installing foreman..."
+      gem install foreman
+    fi
+
+    foreman start -f Procfile.dev "$@"
   BIN
 end
 run("chmod +x bin/dev")
 
 file("bin/run") do
   <<~BIN
-    #!/bin/sh
+    #!/usr/bin/env bash
 
     docker-compose run --no-deps --rm app $*
   BIN
@@ -264,18 +271,20 @@ file("README.md") do
 
     When booting up a local copy of the app for the first time:
 
-    1. Run `bin/dev` to boot up Docker Compose and build Docker images.
-    2. Run `bin/run bin/rails db:setup` to create local databases with seed data.
+    1. Run `bin/compose` to boot up Docker Compose and build Docker images.
+    2. Run `bin/run bin/rails db:create` to create development and test databases.
+    3. Run `bin/run bin/rails db:schema:load` to load in the current schema.
+    4. Run `bin/run bin/rails db:seed` to seed the database.
 
     ### General commands
 
     ```bash
-    $ bin/dev           # Boot up all Docker Compose services
-    $ bin/dev --build   # Build/rebuild all services
-    $ bin/run           # Run a command in the app service
-                        # e.g. bin/run bin/rails test
-                        #      bin/run bundle exec chusaku
-    $ bin/credentials   # Edit encrypted credentials with Vim
+    $ bin/compose           # Boot up all Docker Compose services
+    $ bin/compose --build   # Build/rebuild all services
+    $ bin/run               # Run a command in the app service
+                            # e.g. bin/run bin/rails test
+                            #      bin/run bundle exec chusaku
+    $ bin/credentials       # Edit encrypted credentials with Vim
     ```
 
     ### Linting and annotations
@@ -290,7 +299,7 @@ end
 
 # 7. Initial setup
 #-----------------------------------------------------------------------------------------------------------------------
-run("bin/dev --build --detach")
+run("bin/compose --build --detach")
 run("bin/run bin/rails importmap:install")
 run("bin/run bin/rails turbo:install")
 run("bin/run bin/rails turbo:install:redis")

--- a/dockerized-rails-template.rb
+++ b/dockerized-rails-template.rb
@@ -119,12 +119,8 @@ file("Dockerfile.local") do
     COPY Gemfile.lock /app/
     RUN bundle install
 
-    # Run an entrypoint script.
-    COPY entrypoint.sh /usr/bin/
-    RUN chmod +x /usr/bin/entrypoint.sh
-    ENTRYPOINT ["entrypoint.sh"]
+    # Define default command for the container.
     EXPOSE 3000
-
     CMD ["rails", "server", "-b", "0.0.0.0"]
   DOCKERFILE
 end
@@ -140,6 +136,8 @@ file("docker-compose.yml") do
           dockerfile: ./Dockerfile.local
         volumes:
           - .:/app
+        tmpfs:
+          - /app/tmp/pids
         ports:
           - 3000:3000
         environment:
@@ -179,20 +177,6 @@ file("docker-compose.yml") do
       selenium:
         image: seleniarm/standalone-firefox
   DOCKERCOMPOSE
-end
-
-file("entrypoint.sh") do
-  <<~ENTRYPOINT
-    #!/bin/bash
-
-    set -e
-
-    # Remove a potentially pre-existing server.pid for Rails.
-    rm -f /app/tmp/pids/server.pid
-
-    # Then exec the container's main process (what's set as CMD in the Dockerfile).
-    exec "$@"
-  ENTRYPOINT
 end
 
 # 4. Binstubs


### PR DESCRIPTION
# Overview

Based on some nice suggestions from @defeated:

1. Mount the `tmp/pids` directory as a temporary filesystem via Compose so that we don't have to manage any `entrypoint.sh` shenanigans.
2. Run `web` and `worker` processes via Foreman so we prevent any `bin/dev` or `Procfile.dev` automated config clashes if a user adds a gem that necessitates them. As a bonus, this reduces the number of running Compose services.