### PR TITLE
feat: defend against system test flakes

### DIFF
--- a/dockerized-rails-template.rb
+++ b/dockerized-rails-template.rb
@@ -133,11 +133,12 @@ file("test/test_helper.rb") do
       # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
       fixtures :all
 
-      # Resets Mocktail before every test.
+      # Resets state between tests.
       #
       # @return [void]
       def setup
         Mocktail.reset
+        clear_enqueued_jobs if defined?(clear_enqueued_jobs)
       end
     end
   TESTHELPER

--- a/dockerized-rails-template.rb
+++ b/dockerized-rails-template.rb
@@ -101,7 +101,7 @@ file("test/application_system_test_case.rb") do
         :selenium,
         using: :headless_firefox,
         screen_size: [1400, 1400],
-        options: {url: "http://selenium:4444"}
+        options: {url: "http://selenium:4444", clear_local_storage: true, clear_session_storage: true}
 
       Capybara.enable_aria_label = true
     end


### PR DESCRIPTION
# Overview

This adds a couple lines that helps defend against flakes in system tests for projects:

1. Ensure we're clearing local/session storage between system test runs.
2. Ensure we're clearing test queue jobs between test runs, if applicable.