### PR TITLE
feat: default to UUIDs

### DIFF
--- a/dockerized-rails-template.rb
+++ b/dockerized-rails-template.rb
@@ -85,6 +85,14 @@ file("config/cable.yml") do
   CONFIG
 end
 
+file("config/initializers/generators.rb") do
+  <<~CONFIG
+    Rails.application.config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid, foreign_key_type: :uuid
+    end
+  CONFIG
+end
+
 file("Procfile.dev") do
   <<~PROCFILE
     web: bin/rails server -b 0.0.0.0 -p 3000


### PR DESCRIPTION
# Overview

This makes it so that all generated migrations will default to using Postgres UUIDs as the primary key for new tables.