### PR TITLE
fix: headless Selenium error

### DIFF
--- a/dockerized-rails-template.rb
+++ b/dockerized-rails-template.rb
@@ -109,7 +109,12 @@ file("test/application_system_test_case.rb") do
         :selenium,
         using: :headless_firefox,
         screen_size: [1400, 1400],
-        options: {url: "http://selenium:4444", clear_local_storage: true, clear_session_storage: true}
+        options: {
+          browser: :remote,
+          url: "http://selenium:4444",
+          clear_local_storage: true,
+          clear_session_storage: true
+        }
 
       Capybara.enable_aria_label = true
     end


### PR DESCRIPTION
# Overview

This PR fixes an issue where newer gem versions can't run system tests properly due to the Selenium driver not being configured properly.